### PR TITLE
Fix hint comparison to avoid substring matches

### DIFF
--- a/firewallgen/haproxy.py
+++ b/firewallgen/haproxy.py
@@ -8,7 +8,7 @@ except ImportError:
 
 
 def get_service(ip, port, cfg):
-    term = "{}:{}".format(ip, port)
+    term = "{}:{} ".format(ip, port)
     try:
         with open(cfg) as f:
             lines = f.readlines()


### PR DESCRIPTION
Prevents matching services against incorrect ports when port number is a substring, e.g 80 and 8004